### PR TITLE
Update dlx-json-converter.js

### DIFF
--- a/src/dlx-json-converter.js
+++ b/src/dlx-json-converter.js
@@ -110,10 +110,13 @@ var DLxJsonConverter = Converter.extend(/** @lends DLxJsonConverter# */ {
             };
         });
 
+        var packetInfo = [];
         _.forEach(packetFields, function(packetField) {
-            var headerIndex = allHeaders.indexOf(packetField.packet);
-            var packetInfo = packetInfoList [headerIndex];
-            packetInfo.packetFields.push(packetField);
+            if (packetField.packet !== undefined) {
+                var headerIndex = allHeaders.indexOf(packetField.packet);
+                packetInfo = packetInfoList [headerIndex];
+                packetInfo.packetFields.push(packetField);
+            }
         });
 
         var noneUnit = spec.getUnitById('None');
@@ -194,10 +197,13 @@ var DLxJsonConverter = Converter.extend(/** @lends DLxJsonConverter# */ {
             };
         });
 
+        var packetInfo = [];
         _.forEach(allPacketFields, function(packetField) {
-            var headerIndex = allHeaders.indexOf(packetField.packet);
-            var packetInfo = packetInfoList [headerIndex];
-            packetInfo.packetFields.push(packetField);
+            if (packetField.packet !== undefined) {
+                var headerIndex = allHeaders.indexOf(packetField.packet);
+                packetInfo = packetInfoList [headerIndex];
+                packetInfo.packetFields.push(packetField);
+            }
         });
 
         var headersData = _.reduce(packetInfoList, function(memo, packetInfo, packetInfoIndex) {


### PR DESCRIPTION
If the DLxJsonConverter is instantiated with a specification that based on a specificationData of a filteredPacketFieldSpecs the packetField.packed is undefined if a filteredPacketFieldSpecs packet contains a invalid packetId.

Example (correct):
filteredPacketFieldSpecs = [{ 
    filteredPacketFieldId: 'someId',
    packetId: '01_0010_7E11_10_0100', // packetId = headerId with protocol version, I think... 
    fieldId: '000_2_0',
    name: 'Sensor 1',
    type: 'Number_0_1_DegreesCelsius' 
}]

Example (wrong):
filteredPacketFieldSpecs = [{ 
    filteredPacketFieldId: 'someId',
    packetId: '01_0010_7E11_0100',  // only the headerID!
    fieldId: '000_2_0',
    name: 'Sensor 1',
    type: 'Number_0_1_DegreesCelsius' 
}]
