### PR TITLE
Abort & show msg if require for serialport fails

### DIFF
--- a/src/serial-connection.js
+++ b/src/serial-connection.js
@@ -7,7 +7,9 @@ let SerialPort;
 try {
     SerialPort = require('serialport');
 } catch (ex) {
-    // eat it
+    // throw an error
+    console.log('Error requiring serialport', ex);
+    process.exit(1);
 }
 
 

--- a/src/serial-connection.js
+++ b/src/serial-connection.js
@@ -2,17 +2,6 @@
 'use strict';
 
 
-
-let SerialPort;
-try {
-    SerialPort = require('serialport');
-} catch (ex) {
-    // throw an error
-    console.log('Error requiring serialport', ex);
-    process.exit(1);
-}
-
-
 const Connection = require('./connection');
 const _ = require('./lodash');
 
@@ -203,12 +192,9 @@ const SerialConnection = Connection.extend(/** @lends SerialConnection# */ {
     },
 
     _createSerialPort(path, options, onCompletion) {
+        const SerialPort = require('serialport');
         return new SerialPort(path, options, null, onCompletion);
     }
-
-}, {
-
-    hasSerialPortSupport: !!SerialPort,
 
 });
 

--- a/src/serial-data-source-provider.js
+++ b/src/serial-data-source-provider.js
@@ -3,14 +3,6 @@
 
 
 
-let SerialPort;
-try {
-    SerialPort = require('serialport');
-} catch (ex) {
-    // eat it
-}
-
-
 const _ = require('./lodash');
 const SerialDataSource = require('./serial-data-source');
 
@@ -73,12 +65,9 @@ const SerialDataSourceProvider = DataSourceProvider.extend({
     },
 
     _listSerialPorts() {
+        const SerialPort = require('serialport');
         return SerialPort.list.apply(SerialPort, arguments);
     },
-
-}, {
-
-    hasSerialPortSupport: !!SerialPort,
 
 });
 

--- a/test/specs/test-utils.js
+++ b/test/specs/test-utils.js
@@ -3,11 +3,6 @@
 
 
 
-const {
-    SerialDataSourceProvider,
-} = require('./resol-vbus');
-
-
 const jestExpect = global.expect;
 const expect = require('./expect');
 const _ = require('./lodash');
@@ -61,7 +56,13 @@ const testUtils = {
     serialPortPath,
 
     ifHasSerialPortIt(msg) {
-        if (!SerialDataSourceProvider.hasSerialPortSupport) {
+        let serialPortSupport = false;
+        try {
+            require('serialport');
+            serialPortSupport = true;
+        } catch (ex) {
+        }
+        if (!serialPortSupport) {
             xit(msg + ' (missing serial port support)', () => {});
         } else if (!serialPortPath) {
             xit(msg + ' (missing serial port path)', () => {});


### PR DESCRIPTION
With this little fix you can provide some worthy information to the user.

Error without the fix:
```
error: Connection failed SerialPort is not a constructor
```
What does this mean?!

Error with the fix:
```
Error requiring serialport Error: The module '[...]/node_modules/@serialport/bindings/build/Release/bindings.node'
was compiled against a different Node.js version using
NODE_MODULE_VERSION 83. This version of Node.js requires
NODE_MODULE_VERSION 72. Please try re-compiling or re-installing
the module (for instance, using `npm rebuild` or `npm install`).
```
Yep, that sounds like something I can fix :)