### PR TITLE
Allow parametrization without changeset ID

### DIFF
--- a/docs/vbus-parameterization.md
+++ b/docs/vbus-parameterization.md
@@ -435,8 +435,9 @@ async function main() {
     // console.log(`PeerAddress = 0x${hex(peerAddress, 4)}`);
 
     dgram = await conn.getValueById(peerAddress, 0x00000000);
+    const changeset = dgram ? dgram.value : 0;
     if (!dgram) {
-        console.log(`Unable to get changeset ID`);
+        console.log(`Unable to get changeset ID, using 0 as default`);
     }
 
     // console.log(`Changeset ID = ${hex(dgram.value, 8)}`);
@@ -453,9 +454,11 @@ async function main() {
         }
 
         // Resynchronize between lookup and get/set
-        dgram = await conn.getValueById(peerAddress, 0x00000000);
-        if (!dgram) {
-            console.log(`Unable to get changeset ID`);
+        if (changeset != 0) {
+            dgram = await conn.getValueById(peerAddress, 0x00000000);
+            if (!dgram) {
+                console.log(`Unable to get changeset ID`);
+            }
         }
     }
 
@@ -472,9 +475,11 @@ async function main() {
         }
 
         // Resynchronize between get and set
-        dgram = await conn.getValueById(peerAddress, 0x00000000);
-        if (!dgram) {
-            console.log(`Unable to get changeset ID`);
+        if (changeset != 0) {
+            dgram = await conn.getValueById(peerAddress, 0x00000000);
+            if (!dgram) {
+                console.log(`Unable to get changeset ID`);
+            }
         }
     }
 

--- a/docs/vbus-parameterization.md
+++ b/docs/vbus-parameterization.md
@@ -436,7 +436,7 @@ async function main() {
 
     dgram = await conn.getValueById(peerAddress, 0x00000000);
     if (!dgram) {
-        throw new Error(`Unable to get changeset ID`);
+        console.log(`Unable to get changeset ID`);
     }
 
     // console.log(`Changeset ID = ${hex(dgram.value, 8)}`);
@@ -455,7 +455,7 @@ async function main() {
         // Resynchronize between lookup and get/set
         dgram = await conn.getValueById(peerAddress, 0x00000000);
         if (!dgram) {
-            throw new Error(`Unable to get changeset ID`);
+            console.log(`Unable to get changeset ID`);
         }
     }
 
@@ -474,7 +474,7 @@ async function main() {
         // Resynchronize between get and set
         dgram = await conn.getValueById(peerAddress, 0x00000000);
         if (!dgram) {
-            throw new Error(`Unable to get changeset ID`);
+            console.log(`Unable to get changeset ID`);
         }
     }
 


### PR DESCRIPTION
My Vitosolic 200 does not respond to the changeset request.
I was however able to read (and write) values by using the `ValueIndex` directly like this:

```js
const values = [{
    valueId: 'Vorrang_Sp1',
    valueIdHash: null,
    valueIndex: 0x1000,
    changedValue: null,
    currentValue: null,
},{
    valueId: 'Vorrang_Sp2',
    valueIdHash: null,
    valueIndex: 0x1001,
    changedValue: null,
    currentValue: null,
},{
    valueId: 'Relaismodus1',
    valueIdHash: null,
    valueIndex: 0x01F1,
    changedValue: null,
    currentValue: null,
},{
    valueId: 'Relaismodus4',
    valueIdHash: null,
    valueIndex: 0x01F4,
    changedValue: null,
    currentValue: null,
}];
```

which resulted in:
```console
Datagram `0xAA 0x00 0x00 0x21 0x73 0x20 0x00 0x05 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x46`
    - destination address = `0x0000`
    - source address = `0x7321`
    - command = `0x0500`
    - 16-bit parameter = `0x0000`
    - 32-bit parameter = `0x00000000`
Tx `0xAA 0x21 0x73 0x20 0x00 0x20 0x00 0x03 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x28`
Tx `0xAA 0x21 0x73 0x20 0x00 0x20 0x00 0x03 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x28`
Tx `0xAA 0x21 0x73 0x20 0x00 0x20 0x00 0x03 0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x28`
Unable to get changeset ID

Tx `0xAA 0x21 0x73 0x20 0x00 0x20 0x00 0x03 0x00 0x10 0x00 0x00 0x00 0x00 0x00 0x18`
Datagram `0xAA 0x20 0x00 0x21 0x73 0x20 0x00 0x01 0x00 0x10 0x02 0x00 0x00 0x00 0x00 0x18`
    - destination address = `0x0020`
    - source address = `0x7321`
    - command = `0x0100`
    - 16-bit parameter = `0x1000`
    - 32-bit parameter = `0x00000002`
>> `2`
Tx `0xAA 0x21 0x73 0x20 0x00 0x20 0x00 0x03 0x01 0x10 0x00 0x00 0x00 0x00 0x00 0x17`
Datagram `0xAA 0x20 0x00 0x21 0x73 0x20 0x00 0x01 0x01 0x10 0x01 0x00 0x00 0x00 0x00 0x18`
    - destination address = `0x0020`
    - source address = `0x7321`
    - command = `0x0100`
    - 16-bit parameter = `0x1001`
    - 32-bit parameter = `0x00000001`
>> `1`
Tx `0xAA 0x21 0x73 0x20 0x00 0x20 0x00 0x03 0x71 0x01 0x00 0x00 0x00 0x00 0x01 0x35`
Datagram `0xAA 0x20 0x00 0x21 0x73 0x20 0x00 0x01 0x71 0x01 0x01 0x00 0x00 0x00 0x01 0x36`
    - destination address = `0x0020`
    - source address = `0x7321`
    - command = `0x0100`
    - 16-bit parameter = `0x01F1`
    - 32-bit parameter = `0x00000001`
>> `1`
Tx `0xAA 0x21 0x73 0x20 0x00 0x20 0x00 0x03 0x74 0x01 0x00 0x00 0x00 0x00 0x01 0x32`
Datagram `0xAA 0x20 0x00 0x21 0x73 0x20 0x00 0x01 0x74 0x01 0x01 0x00 0x00 0x00 0x01 0x33`
    - destination address = `0x0020`
    - source address = `0x7321`
    - command = `0x0100`
    - 16-bit parameter = `0x01F4`
    - 32-bit parameter = `0x00000001`
>> `1`
```